### PR TITLE
API: Remove int return from ReveryTerminal.write

### DIFF
--- a/src/lib/ReveryTerminal.re
+++ b/src/lib/ReveryTerminal.re
@@ -82,7 +82,7 @@ let resize = (~rows, ~columns, {vterm, screen, _}) => {
 };
 
 let write = (~input: string, {vterm, _}) => {
-  Vterm.write(~input, vterm);
+  Vterm.write(~input, vterm) |> (ignore: int => unit);
 };
 
 let input = (~key: int32, {vterm, _}) => {

--- a/src/lib/ReveryTerminal.rei
+++ b/src/lib/ReveryTerminal.rei
@@ -42,7 +42,7 @@ type unsubscribe = unit => unit;
 
 let make: (~rows: int, ~columns: int, ~onEffect: effect => unit) => t;
 
-let write: (~input: string, t) => int;
+let write: (~input: string, t) => unit;
 let input: (~key: int32, t) => unit;
 let resize: (~rows: int, ~columns: int, t) => unit;
 


### PR DESCRIPTION
This simplifies the `ReveryTerminal.write` API - the consumer shouldn't need to care about the number of characters written, we should be able to abstract that in our interface (thanks for the suggestion @glennsl )