### PR TITLE
Bugfix: Hang on large write

### DIFF
--- a/src/lib/ReveryTerminal.re
+++ b/src/lib/ReveryTerminal.re
@@ -78,8 +78,7 @@ let make =
         let damages = ref([]);
         for (x in startCol to endCol - 1) {
           for (y in startRow to endRow - 1) {
-            damages :=
-              [Screen.DamageInfo.{row: y, col: x}, ...damages^];
+            damages := [Screen.DamageInfo.{row: y, col: x}, ...damages^];
           };
         };
         screen := Screen.damaged(screen^, damages^);

--- a/src/lib/ReveryTerminal.re
+++ b/src/lib/ReveryTerminal.re
@@ -29,7 +29,7 @@ let make =
     ) => {
   let cursor = ref(Cursor.initial);
   let vterm = Vterm.make(~rows, ~cols=columns);
-  let screen = ref(Screen.make(~scrollBackSize, ~rows, ~columns));
+  let screen = ref(Screen.make(~vterm, ~scrollBackSize, ~rows, ~columns));
   Vterm.setUtf8(~utf8=true, vterm);
   Vterm.Screen.setAltScreen(~enabled=true, vterm);
 
@@ -78,9 +78,8 @@ let make =
         let damages = ref([]);
         for (x in startCol to endCol - 1) {
           for (y in startRow to endRow - 1) {
-            let cell = Vterm.Screen.getCell(~row=y, ~col=x, vterm);
             damages :=
-              [Screen.DamageInfo.{row: y, col: x, cell}, ...damages^];
+              [Screen.DamageInfo.{row: y, col: x}, ...damages^];
           };
         };
         screen := Screen.damaged(screen^, damages^);
@@ -105,8 +104,7 @@ let resize = (~rows, ~columns, {vterm, screen, _}) => {
   let damages = ref([]);
   for (x in 0 to columns - 1) {
     for (y in 0 to rows - 1) {
-      let cell = Vterm.Screen.getCell(~row=y, ~col=x, vterm);
-      damages := [Screen.DamageInfo.{row: y, col: x, cell}, ...damages^];
+      damages := [Screen.DamageInfo.{row: y, col: x}, ...damages^];
     };
   };
   screen := Screen.damaged(screen^, damages^);

--- a/src/lib/Screen.re
+++ b/src/lib/Screen.re
@@ -17,25 +17,20 @@ type t = {
 
 let getVisibleCell = (~row, ~column, screen) => {
   switch (screen.vterm) {
-  | None => Vterm.ScreenCell.empty;
+  | None => Vterm.ScreenCell.empty
   | Some(vterm) =>
     let idx = row * screen.columns + column;
     if (idx >= Array.length(screen.cells)) {
       Vterm.ScreenCell.empty;
     } else {
-
       if (screen.dirtyCells[idx]) {
-        screen.cells[idx] = Vterm.Screen.getCell(
-          ~row,
-          ~col=column,
-          vterm,
-        );
+        screen.cells[idx] = Vterm.Screen.getCell(~row, ~col=column, vterm);
         screen.dirtyCells[idx] = false;
-      } 
-    
+      };
+
       screen.cells[idx];
     };
-  }
+  };
 };
 
 let updateCell = ({columns, cells, dirtyCells, _}, damage: DamageInfo.t) => {

--- a/src/lib/Screen.re
+++ b/src/lib/Screen.re
@@ -2,7 +2,6 @@ module DamageInfo = {
   type t = {
     row: int,
     col: int,
-    cell: Vterm.ScreenCell.t,
   };
 };
 
@@ -10,31 +9,47 @@ type t = {
   damageCounter: int,
   rows: int,
   columns: int,
+  dirtyCells: array(bool),
   cells: array(Vterm.ScreenCell.t),
   scrollBack: RingBuffer.t(array(Vterm.ScreenCell.t)),
+  vterm: option(Vterm.t),
 };
 
 let getVisibleCell = (~row, ~column, screen) => {
-  let idx = row * screen.columns + column;
-  if (idx >= Array.length(screen.cells)) {
-    Vterm.ScreenCell.empty;
-  } else {
-    screen.cells[idx];
-  };
+  switch (screen.vterm) {
+  | None => Vterm.ScreenCell.empty;
+  | Some(vterm) =>
+    let idx = row * screen.columns + column;
+    if (idx >= Array.length(screen.cells)) {
+      Vterm.ScreenCell.empty;
+    } else {
+
+      if (screen.dirtyCells[idx]) {
+        screen.cells[idx] = Vterm.Screen.getCell(
+          ~row,
+          ~col=column,
+          vterm,
+        );
+        screen.dirtyCells[idx] = false;
+      } 
+    
+      screen.cells[idx];
+    };
+  }
 };
 
-let updateCell = ({columns, cells, _}, damage: DamageInfo.t) => {
+let updateCell = ({columns, cells, dirtyCells, _}, damage: DamageInfo.t) => {
   let idx = damage.row * columns + damage.col;
-  cells[idx] = damage.cell;
+  dirtyCells[idx] = true;
 };
 
-let updateCells = (model, damages) => {
+let updateDirtyCells = (model, damages) => {
   List.iter(updateCell(model), damages);
 };
 
 let damaged = (model, damages: list(DamageInfo.t)) => {
   // UGLY MUTATION
-  updateCells(model, damages);
+  updateDirtyCells(model, damages);
   {...model, damageCounter: model.damageCounter + 1};
 };
 
@@ -50,7 +65,6 @@ let pushScrollback = (~cells, screen) => {
 let popScrollback = (~cells as _, screen) => {
   {
     // TODO
-
     ...screen,
     damageCounter: screen.damageCounter + 1,
   };
@@ -78,22 +92,27 @@ let resize = (~rows, ~columns, model) => {
     damageCounter: model.damageCounter + 1,
     rows,
     columns,
+    dirtyCells: Array.make(rows * columns, true),
     cells: Array.make(rows * columns, Vterm.ScreenCell.empty),
   };
 };
 
-let make = (~scrollBackSize, ~rows, ~columns) => {
+let make = (~vterm: Vterm.t, ~scrollBackSize, ~rows, ~columns) => {
   damageCounter: 0,
   rows: 0,
   columns: 0,
+  dirtyCells: Array.make(rows * columns, true),
   cells: Array.make(rows * columns, Vterm.ScreenCell.empty),
   scrollBack: RingBuffer.make(~capacity=scrollBackSize, [||]),
+  vterm: Some(vterm),
 };
 
 let initial = {
   damageCounter: 0,
   rows: 0,
   columns: 0,
+  dirtyCells: Array.make(0, true),
   cells: Array.make(0, Vterm.ScreenCell.empty),
   scrollBack: RingBuffer.make(~capacity=0, [||]),
+  vterm: None,
 };

--- a/src/lib/TerminalView.re
+++ b/src/lib/TerminalView.re
@@ -174,8 +174,8 @@ let%component make =
                let codeInt = Uchar.to_int(cell.char);
                if (codeInt !== 0) {
                  Buffer.clear(buffer);
-                 // Need to validate the code point, otherwise we can hit an assertion in 
-                 // the standard library: 
+                 // Need to validate the code point, otherwise we can hit an assertion in
+                 // the standard library:
                  // https://github.com/ocaml/ocaml/blob/849bf6239dd0f9dae45b945c92e24f41d27fd3ad/stdlib/buffer.ml#L117
                  if (codeInt <= 0x10FFFF) {
                    Buffer.add_utf_8_uchar(buffer, cell.char);
@@ -187,7 +187,7 @@ let%component make =
                      ~text=str,
                      canvasContext,
                    );
-                 }
+                 };
                };
              }};
 

--- a/src/lib/TerminalView.re
+++ b/src/lib/TerminalView.re
@@ -161,7 +161,7 @@ let%component make =
                };
              }};
 
-          let buffer = Buffer.create(4);
+          let buffer = Buffer.create(16);
 
           let renderText = (row, yOffset) =>
             {for (column in 0 to columns - 1) {
@@ -174,15 +174,20 @@ let%component make =
                let codeInt = Uchar.to_int(cell.char);
                if (codeInt !== 0) {
                  Buffer.clear(buffer);
-                 Buffer.add_utf_8_uchar(buffer, cell.char);
-                 let str = Buffer.contents(buffer);
-                 CanvasContext.drawText(
-                   ~paint=textPaint,
-                   ~x=float(column) *. characterWidth,
-                   ~y=yOffset +. characterHeight,
-                   ~text=str,
-                   canvasContext,
-                 );
+                 // Need to validate the code point, otherwise we can hit an assertion in 
+                 // the standard library: 
+                 // https://github.com/ocaml/ocaml/blob/849bf6239dd0f9dae45b945c92e24f41d27fd3ad/stdlib/buffer.ml#L117
+                 if (codeInt <= 0x10FFFF) {
+                   Buffer.add_utf_8_uchar(buffer, cell.char);
+                   let str = Buffer.contents(buffer);
+                   CanvasContext.drawText(
+                     ~paint=textPaint,
+                     ~x=float(column) *. characterWidth,
+                     ~y=yOffset +. characterHeight,
+                     ~text=str,
+                     canvasContext,
+                   );
+                 }
                };
              }};
 


### PR DESCRIPTION
This fixes the root cause of https://github.com/onivim/oni2/issues/1402, where issuing a command that has a lot of output can cause the editor / terminal to totally hang.

The issue is that, for every damage, we were querying for info about the screen cell (which is expensive and incurs allocation). We were doing that way too frequently, such that we couldn't keep up with the output from the process.

The fix is to simply mark cells as damaged - and then we'll query for the state when we go to render. We'll cache the result until it is marked dirty again by a damage from vterm.