### PR TITLE
Perf: Improve rendering performance

### DIFF
--- a/src/lib/Accumulator.re
+++ b/src/lib/Accumulator.re
@@ -70,7 +70,7 @@ module BackgroundColorAccumulator = {
         endColumn: item.column + 1,
         color: item.color,
       })
-    | Some({color, startColumn, endColumn}) =>
+    | Some({color, startColumn, _}) =>
       Some({startColumn, endColumn: item.column + 1, color})
     };
 

--- a/src/lib/Accumulator.re
+++ b/src/lib/Accumulator.re
@@ -1,0 +1,144 @@
+module Accumulator = {
+  type t('state, 'item) = {
+    initialState: 'state,
+    currentState: 'state,
+    shouldMerge: ('state, 'item) => bool,
+    merge: ('state, 'item) => 'state,
+    flush: 'state => unit,
+  };
+
+  let create =
+      (
+        ~initialState: 'state,
+        ~shouldMerge: ('state, 'item) => bool,
+        ~merge: ('state, 'item) => 'state,
+        ~flush: 'state => unit,
+      ) => {
+    currentState: initialState,
+    initialState,
+    shouldMerge,
+    merge,
+    flush,
+  };
+
+  let add = (item: 'item, accumulator: t('state, 'item)) => {
+    let {shouldMerge, currentState, merge, flush, initialState} = accumulator;
+    if (shouldMerge(currentState, item)) {
+      let newState = merge(currentState, item);
+      {...accumulator, currentState: newState};
+    } else {
+      flush(accumulator.currentState);
+      let newState = merge(initialState, item);
+      {...accumulator, currentState: newState};
+    };
+  };
+
+  let flush = accumulator => {
+    accumulator.flush(accumulator.currentState);
+  };
+};
+
+module BackgroundColorAccumulator = {
+  type cells = {
+    startColumn: int,
+    endColumn: int,
+    color: Skia.Color.t,
+  };
+
+  type state = option(cells);
+
+  type item = {
+    color: Skia.Color.t,
+    column: int,
+  };
+
+  type t = Accumulator.t(state, item);
+
+  let initialState = None;
+
+  let shouldMerge = (state, item) =>
+    switch (state) {
+    | None => true
+    | Some(({color, _}: cells)) => color == item.color
+    };
+
+  let merge = (state: state, item: item) =>
+    switch (state) {
+    | None =>
+      Some({
+        startColumn: item.column,
+        endColumn: item.column + 1,
+        color: item.color,
+      })
+    | Some({color, startColumn, endColumn}) =>
+      Some({startColumn, endColumn: item.column + 1, color})
+    };
+
+  let create = draw => {
+    let flush: state => unit =
+      state => {
+        switch (state) {
+        | None => ()
+        | Some(state) =>
+          draw(state.startColumn, state.endColumn, state.color)
+        };
+      };
+
+    Accumulator.create(~initialState, ~shouldMerge, ~merge, ~flush);
+  };
+};
+
+module TextAccumulator = {
+  type cells = {
+    startColumn: int,
+    color: Skia.Color.t,
+    buffer: Buffer.t,
+  };
+
+  type state = option(cells);
+
+  type item = {
+    column: int,
+    uchar: Uchar.t,
+    color: Skia.Color.t,
+  };
+
+  let isValidUchar = uchar => {
+    let codeInt = Uchar.to_int(uchar);
+
+    codeInt !== 0 && codeInt <= 0x10FFF;
+  };
+
+  let shouldMerge = (state: state, item: item) =>
+    switch (state) {
+    | None => true
+    | Some({color, _}) => color == item.color && isValidUchar(item.uchar)
+    };
+
+  let merge: (state, item) => state =
+    (state: state, item: item) =>
+      switch (state) {
+      | None when !isValidUchar(item.uchar) => None
+      | None =>
+        let buffer = Buffer.create(16);
+        Buffer.add_utf_8_uchar(buffer, item.uchar);
+        Some({startColumn: item.column, color: item.color, buffer});
+      | Some({startColumn, buffer, color}) =>
+        Buffer.add_utf_8_uchar(buffer, item.uchar);
+        Some({startColumn, buffer, color});
+      };
+
+  let initialState = None;
+
+  let create = draw => {
+    let flush: state => unit =
+      state => {
+        switch (state) {
+        | None => ()
+        | Some(state) => draw(state.startColumn, state.buffer, state.color)
+        };
+      };
+
+    Accumulator.create(~initialState, ~shouldMerge, ~merge, ~flush);
+  };
+};

--- a/src/lib/ReveryTerminal.re
+++ b/src/lib/ReveryTerminal.re
@@ -75,14 +75,13 @@ let make =
   Vterm.Screen.setDamageCallback(
     ~onDamage=
       ({startRow, startCol, endRow, endCol}: Vterm.Rect.t) => {
-        let damages = ref([]);
-        for (x in startCol to endCol - 1) {
-          for (y in startRow to endRow - 1) {
-            damages :=
-              [Screen.Internal.DamageInfo.{row: y, col: x}, ...damages^];
+        let _screen = screen^;
+        for (col in startCol to endCol - 1) {
+          for (row in startRow to endRow - 1) {
+            Screen.Internal.markDamaged(_screen, row, col);
           };
         };
-        screen := Screen.Internal.damaged(screen^, damages^);
+        screen := Screen.Internal.bumpDamageCounter(_screen);
         dispatch(ScreenUpdated(screen^));
       },
     vterm,
@@ -101,13 +100,13 @@ let resize = (~rows, ~columns, {vterm, screen, _}) => {
   Vterm.setSize(~size={rows, cols: columns}, vterm);
 
   // After the size changed - re-get all the cells
-  let damages = ref([]);
-  for (x in 0 to columns - 1) {
-    for (y in 0 to rows - 1) {
-      damages := [Screen.Internal.DamageInfo.{row: y, col: x}, ...damages^];
+  let _screen = screen^;
+  for (col in 0 to columns - 1) {
+    for (row in 0 to rows - 1) {
+      Screen.Internal.markDamaged(_screen, row, col);
     };
   };
-  screen := Screen.Internal.damaged(screen^, damages^);
+  screen := Screen.Internal.bumpDamageCounter(_screen);
 };
 
 let write = (~input: string, {vterm, _}) => {

--- a/src/lib/Screen.re
+++ b/src/lib/Screen.re
@@ -14,9 +14,12 @@ module Internal = {
     dirtyCells[idx] = true;
   };
 
-  let bumpDamageCounter = (model) => {
-    // UGLY MUTATION
-    {...model, damageCounter: model.damageCounter + 1};
+  let bumpDamageCounter = model => {
+    {
+      // UGLY MUTATION
+      ...model,
+      damageCounter: model.damageCounter + 1,
+    };
   };
 
   let getColor =

--- a/src/lib/Screen.re
+++ b/src/lib/Screen.re
@@ -9,24 +9,13 @@ type t = {
 };
 
 module Internal = {
-  module DamageInfo = {
-    type t = {
-      row: int,
-      col: int,
-    };
-  };
-
-  let updateCell = ({columns, dirtyCells, _}, damage: DamageInfo.t) => {
-    let idx = damage.row * columns + damage.col;
+  let markDamaged = ({columns, dirtyCells, _}, row, col) => {
+    let idx = row * columns + col;
     dirtyCells[idx] = true;
   };
 
-  let updateDirtyCells = (model, damages) => {
-    List.iter(updateCell(model), damages);
-  };
-  let damaged = (model, damages: list(DamageInfo.t)) => {
+  let bumpDamageCounter = (model) => {
     // UGLY MUTATION
-    updateDirtyCells(model, damages);
     {...model, damageCounter: model.damageCounter + 1};
   };
 

--- a/src/lib/TerminalView.re
+++ b/src/lib/TerminalView.re
@@ -3,6 +3,8 @@ module Colors = Revery.Colors;
 open Revery.Draw;
 open Revery.UI;
 
+open Accumulator;
+
 module Styles = {
   let container = bg =>
     Style.[
@@ -23,151 +25,6 @@ module Styles = {
 type terminalSize = {
   width: int,
   height: int,
-};
-
-module Accumulator = {
-  type t('state, 'item) = {
-    initialState: 'state,
-    currentState: 'state,
-    shouldMerge: ('state, 'item) => bool,
-    merge: ('state, 'item) => 'state,
-    flush: 'state => unit,
-  };
-
-  let create =
-      (
-        ~initialState: 'state,
-        ~shouldMerge: ('state, 'item) => bool,
-        ~merge: ('state, 'item) => 'state,
-        ~flush: 'state => unit,
-      ) => {
-    currentState: initialState,
-    initialState,
-    shouldMerge,
-    merge,
-    flush,
-  };
-
-  let add = (item: 'item, accumulator: t('state, 'item)) => {
-    let {shouldMerge, currentState, merge, flush, initialState} = accumulator;
-    if (shouldMerge(currentState, item)) {
-      let newState = merge(currentState, item);
-      {...accumulator, currentState: newState};
-    } else {
-      flush(accumulator.currentState);
-      let newState = merge(initialState, item);
-      {...accumulator, currentState: newState};
-    };
-  };
-
-  let flush = accumulator => {
-    accumulator.flush(accumulator.currentState);
-  };
-};
-
-module BackgroundColorAccumulator = {
-  type cells = {
-    startColumn: int,
-    endColumn: int,
-    color: Skia.Color.t,
-  };
-
-  type state = option(cells);
-
-  type item = {
-    color: Skia.Color.t,
-    column: int,
-  };
-
-  type t = Accumulator.t(state, item);
-
-  let initialState = None;
-
-  let shouldMerge = (state, item) =>
-    switch (state) {
-    | None => true
-    | Some(({color, _}: cells)) => color == item.color
-    };
-
-  let merge = (state: state, item: item) =>
-    switch (state) {
-    | None =>
-      Some({
-        startColumn: item.column,
-        endColumn: item.column + 1,
-        color: item.color,
-      })
-    | Some({color, startColumn, endColumn}) =>
-      Some({startColumn, endColumn: item.column + 1, color})
-    };
-
-  let create = draw => {
-    let flush: state => unit =
-      state => {
-        switch (state) {
-        | None => ()
-        | Some(state) =>
-          draw(state.startColumn, state.endColumn, state.color)
-        };
-      };
-
-    Accumulator.create(~initialState, ~shouldMerge, ~merge, ~flush);
-  };
-};
-
-module TextAccumulator = {
-  type cells = {
-    startColumn: int,
-    color: Skia.Color.t,
-    buffer: Buffer.t,
-  };
-
-  type state = option(cells);
-
-  type item = {
-    column: int,
-    uchar: Uchar.t,
-    color: Skia.Color.t,
-  };
-
-  let isValidUchar = uchar => {
-    let codeInt = Uchar.to_int(uchar);
-
-    codeInt !== 0 && codeInt <= 0x10FFF;
-  };
-
-  let shouldMerge = (state: state, item: item) =>
-    switch (state) {
-    | None => true
-    | Some({color, _}) => color == item.color && isValidUchar(item.uchar)
-    };
-
-  let merge: (state, item) => state =
-    (state: state, item: item) =>
-      switch (state) {
-      | None when !isValidUchar(item.uchar) => None
-      | None =>
-        let buffer = Buffer.create(16);
-        Buffer.add_utf_8_uchar(buffer, item.uchar);
-        Some({startColumn: item.column, color: item.color, buffer});
-      | Some({startColumn, buffer, color}) =>
-        Buffer.add_utf_8_uchar(buffer, item.uchar);
-        Some({startColumn, buffer, color});
-      };
-
-  let initialState = None;
-
-  let create = draw => {
-    let flush: state => unit =
-      state => {
-        switch (state) {
-        | None => ()
-        | Some(state) => draw(state.startColumn, state.buffer, state.color)
-        };
-      };
-
-    Accumulator.create(~initialState, ~shouldMerge, ~merge, ~flush);
-  };
 };
 
 let%component make =
@@ -300,8 +157,6 @@ let%component make =
                accumulator := Accumulator.add(item, accumulator^);
              };
              Accumulator.flush(accumulator^)};
-
-          let buffer = Buffer.create(16);
 
           let renderText = (row, yOffset) =>
             {Skia.Paint.setTextEncoding(textPaint, Utf8);


### PR DESCRIPTION
This implements a few fixes to improve rendering performance:

- In the background pre-draw, accumulate cells in a row, so we don't need to draw rectangles individually
- In the foreground draw, accumulate text, so we can draw it in chunks, as opposed to drawing each character individually.
- Reduce allocations for 'damage' notifications, which come frequently