### PR TITLE
feat(terminal): shape text received from vterm

### DIFF
--- a/src/lib/TerminalView.re
+++ b/src/lib/TerminalView.re
@@ -159,18 +159,29 @@ let%component make =
              Accumulator.flush(accumulator^)};
 
           let renderText = (row, yOffset) =>
-            {Skia.Paint.setTextEncoding(textPaint, Utf8);
+            {Skia.Paint.setTextEncoding(textPaint, GlyphId);
              let accumulator =
                ref(
                  TextAccumulator.create((startColumn, buffer, color) => {
                    Skia.Paint.setColor(textPaint, color);
                    let str = Buffer.contents(buffer);
-                   CanvasContext.drawText(
-                     ~paint=textPaint,
-                     ~x=float(startColumn) *. characterWidth,
-                     ~y=yOffset +. characterHeight,
-                     ~text=str,
-                     canvasContext,
+                   let tokens =
+                     str
+                     |> Revery.Font.shape(font)
+                     |> Revery.Font.ShapeResult.getGlyphStrings;
+                   List.iter(
+                     ((skiaFace, str)) => {
+                       Skia.Paint.setTypeface(textPaint, skiaFace);
+
+                       CanvasContext.drawText(
+                         ~paint=textPaint,
+                         ~x=float(startColumn) *. characterWidth,
+                         ~y=yOffset +. characterHeight,
+                         ~text=str,
+                         canvasContext,
+                       );
+                     },
+                     tokens,
                    );
                  }),
                );


### PR DESCRIPTION
This passes the text received from `libvterm` using Harfbuzz. This also enables font fallback:

![image](https://user-images.githubusercontent.com/4527949/88211860-4a8f0f80-cc24-11ea-94d4-c0e0cffcad60.png)
